### PR TITLE
use alternative sql subscription method

### DIFF
--- a/grape-middleware-lograge.gemspec
+++ b/grape-middleware-lograge.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'grape-middleware-lograge'
-  spec.version       = '1.2.3'
+  spec.version       = '1.2.4'
   spec.platform      = Gem::Platform::RUBY
   spec.authors       = ['Ryan Buckley', 'Paul Chavard']
   spec.email         = ['arebuckley@gmail.com', 'paul+github@chavard.net']

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -18,15 +18,30 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @options[:filter] ||= self.class.filter
   end
 
+  class SQLSubscriber
+    attr_reader :db_duration
+
+    def initialize
+      @db_duration = 0
+    end
+
+    def start(name, id, payload)
+      @start = Time.now
+    end
+
+    def finish(name, id, payload)
+      @db_duration += 1000.0 * (Time.now - @start)
+    end
+  end
+
   def before
     super
 
-    @db_duration = 0
+    @sql_subscriber = SQLSubscriber.new
 
-    @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-      event = ActiveSupport::Notifications::Event.new(*args)
-      @db_duration += event.duration
-    end if defined?(ActiveRecord)
+    if defined?(ActiveRecord)
+      @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record', @sql_subscriber)
+    end
 
     ActiveSupport::Notifications.instrument("start_processing.grape", raw_payload)
   end
@@ -66,7 +81,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     payload[:status]     = status
     payload[:format]     = env['api.format']
     payload[:version]    = env['api.version']
-    payload[:db_runtime] = @db_duration
+    payload[:db_runtime] = @sql_subscriber.try(:db_duration)
   end
 
   def after_exception(payload, e)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -30,7 +30,9 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     end
 
     def finish(name, id, payload)
-      @db_duration += 1000.0 * (Time.now - @start)
+      if @start
+        @db_duration += 1000.0 * (Time.now - @start)
+      end
     end
   end
 


### PR DESCRIPTION
- fixes #1 

This "fix" takes the approach mentioned in the comments at rails/rails#12069.  It leverages an alternative but still public api, and just tracks the duration internally rather than using the subscription args.