### PR TITLE
intermittent nil start time

### DIFF
--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,7 +24,6 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-      args[1] ||= Time.now
       event = ActiveSupport::Notifications::Event.new(*args)
       @db_duration += event.duration
     end if defined?(ActiveRecord)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,6 +24,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      args[1] ||= Time.now # occasionally the start time is nil and will cause errors in Event
       event = ActiveSupport::Notifications::Event.new(*args)
       @db_duration += event.duration
     end if defined?(ActiveRecord)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,6 +24,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      args[1] ||= Time.now
       event = ActiveSupport::Notifications::Event.new(*args)
       @db_duration += event.duration
     end if defined?(ActiveRecord)


### PR DESCRIPTION
In lib/grape/middleware/lograge.rb ActiveSupport::Notifications.subscribe('sql.active_record') sometimes sets the start time to nil which causes ActiveSupport::Notifications::Event to blow up, producing stack traces in my app like:

> can't convert nil into an exact number
> "/opt/delta_core/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.8/lib/active_support/core_ext/time/calculations.rb:240:in `-'",
> "/opt/delta_core/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.8/lib/active_support/core_ext/time/calculations.rb:240:in `minus_with_duration'",
> "/opt/delta_core/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.8/lib/active_support/core_ext/time/calculations.rb:251:in `minus_with_coercion'",
> "/opt/delta_core/shared/bundle/ruby/2.3.0/gems/activesupport-4.2.8/lib/active_support/notifications/instrumenter.rb:61:in `duration'",
> "/opt/delta_core/shared/bundle/ruby/2.3.0/bundler/gems/grape-middleware-lograge-3daaa11d7114/lib/grape/middleware/lograge.rb:28:in `block in before'"

Simply initializing the start time if it is unset obviates the error, though I'm not sure at all that Time.now is the proper value to initialize it.