### PR TITLE
2 memory leak from db duration

### DIFF
--- a/grape-middleware-lograge.gemspec
+++ b/grape-middleware-lograge.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'grape-middleware-lograge'
-  spec.version       = '1.2.3'
+  spec.version       = '1.2.4'
   spec.platform      = Gem::Platform::RUBY
   spec.authors       = ['Ryan Buckley', 'Paul Chavard']
   spec.email         = ['arebuckley@gmail.com', 'paul+github@chavard.net']
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'grape', '>= 0.14', '< 1'
+  spec.add_dependency 'grape', '>= 0.14'
   spec.add_dependency 'lograge', '~> 0.3'
 
   spec.add_development_dependency 'bundler', '~> 1.7'

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,7 +24,6 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-      args[1] ||= Time.now
       event = ActiveSupport::Notifications::Event.new(*args)
       @db_duration += event.duration
     end if defined?(ActiveRecord)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,7 +24,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, start, ending, transaction_id, payload|
-      @db_duration += 1000.0 * ending - start if ending && start
+      @db_duration += 1000.0 * (ending - start) if ending && start
     end if defined?(ActiveRecord)
 
     ActiveSupport::Notifications.instrument("start_processing.grape", raw_payload)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -23,7 +23,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
 
     @db_runtime = 0
 
-    @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, start, ending, transaction_id, payload|
+    @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |_name, start, ending, _transaction_id, _payload|
       @db_runtime += 1000.0 * (ending - start) if ending && start
     end if defined?(ActiveRecord)
 
@@ -62,6 +62,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
   end
 
   def after(payload, status)
+    ActiveSupport::Notifications.unsubscribe(@db_subscription) if @db_subscription
     payload[:status]     = status
     payload[:format]     = env['api.format']
     payload[:version]    = env['api.version']

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -24,6 +24,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      args[1] ||= Time.now
       event = ActiveSupport::Notifications::Event.new(*args)
       @db_duration += event.duration
     end if defined?(ActiveRecord)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -21,7 +21,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
   def before
     super
 
-    @db_duration = 0.0
+    @db_duration = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, start, ending, transaction_id, payload|
       @db_duration += 1000.0 * ending - start if ending && start

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -21,10 +21,10 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
   def before
     super
 
-    @db_duration = 0
+    @db_runtime = 0
 
     @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, start, ending, transaction_id, payload|
-      @db_duration += 1000.0 * (ending - start) if ending && start
+      @db_runtime += 1000.0 * (ending - start) if ending && start
     end if defined?(ActiveRecord)
 
     ActiveSupport::Notifications.instrument("start_processing.grape", raw_payload)
@@ -65,7 +65,7 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
     payload[:status]     = status
     payload[:format]     = env['api.format']
     payload[:version]    = env['api.version']
-    payload[:db_runtime] = @db_duration
+    payload[:db_runtime] = @db_runtime
   end
 
   def after_exception(payload, e)

--- a/lib/grape/middleware/lograge.rb
+++ b/lib/grape/middleware/lograge.rb
@@ -21,11 +21,10 @@ class Grape::Middleware::Lograge < Grape::Middleware::Globals
   def before
     super
 
-    @db_duration = 0
+    @db_duration = 0.0
 
-    @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
-      event = ActiveSupport::Notifications::Event.new(*args)
-      @db_duration += event.duration
+    @db_subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |name, start, ending, transaction_id, payload|
+      @db_duration += 1000.0 * ending - start if ending && start
     end if defined?(ActiveRecord)
 
     ActiveSupport::Notifications.instrument("start_processing.grape", raw_payload)


### PR DESCRIPTION
The ActiveSupport::Notifications::Event object will blow up sometimes when the start time passed from ActiveSupport::Notifications.subscribe('sql.active_record') is nil. Fixing that problem gave rise to something like a memory leak as the Event objects proliferate with every request, while doing very little. We could simply make the calculation it performs ourselves and greatly improve performance.

Before this change in my app under load the performance severely degraded very quickly (the load average on the box rose to over 20). The spikes on the right here are when the box was under load, flattening out when I hit the emergency breaks on our load tests:

<img width="805" alt="screen shot 2018-04-27 at 12 59 19 pm" src="https://user-images.githubusercontent.com/377180/39384164-b2d87820-4a20-11e8-845f-af0fc1ace8c5.png">
<img width="1186" alt="screen shot 2018-04-27 at 1 04 39 pm" src="https://user-images.githubusercontent.com/377180/39384138-9eebece8-4a20-11e8-88ce-97c2f5a81f35.png">

After the change under the same load it faired much much better (the spikes the left are the deployment):

<img width="1177" alt="screen shot 2018-04-27 at 1 42 45 pm" src="https://user-images.githubusercontent.com/377180/39384246-f0ff173a-4a20-11e8-8ebe-b49c8877ab3c.png">
<img width="810" alt="screen shot 2018-04-27 at 1 43 00 pm" src="https://user-images.githubusercontent.com/377180/39384254-f5e2bdec-4a20-11e8-95da-463bda6b3e53.png">
